### PR TITLE
build: fix ci cacheing to use recently built caches

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -6,8 +6,5 @@ build --announce_rc
 # Don't rely on test logs being easily accessible from the test runner,
 # though it makes the log noisier.
 test --test_output=errors
-# This directory is configured in GitHub actions to be persisted between runs.
-build --disk_cache=$HOME/.cache/bazel
-build --repository_cache=$HOME/.cache/bazel-repo
 # Allows tests to run bazelisk-in-bazel, since this is the cache folder used
 test --test_env=XDG_CACHE_HOME

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,18 +20,34 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-      - name: Mount bazel action cache
+      # Cache build and external artifacts so that the next ci build is incremental.
+      # Because github action caches cannot be updated after a build, we need to
+      # store the contents of each build in a unique cache key, then fall back to loading
+      # it on the next ci run. We use hashFiles(...) in the key and restore-keys- with
+      # the prefix to load the most recent cache for the branch on a cache miss. You
+      # should customize the contents of hashFiles to capture any bazel input sources,
+      # although this doesn't need to be perfect. If none of the input sources change
+      # then a cache hit will load an existing cache and bazel won't have to do any work.
+      # In the case of a cache miss, you want the fallback cache to contain most of the
+      # previously built artifacts to minimize build time. The more precise you are with
+      # hashFiles sources the less work bazel will have to do.
+      - name: Mount bazel caches
         uses: actions/cache@v2
         with:
-          path: "~/.cache/bazel"
-          key: bazel
-      - name: Mount bazel repo cache
-        uses: actions/cache@v2
-        with:
-          path: "~/.cache/bazel-repo"
-          key: bazel-repo
+          path: |
+            "~/.cache/bazel"
+            "~/.cache/bazel-repo"
+          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
+          restore-keys: bazel-cache-
       - name: bazel test //...
         env:
           # Bazelisk will download bazel to here, ensure it is cached between runs.
           XDG_CACHE_HOME: ~/.cache/bazel-repo
-        run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
+        run: |
+          bazel \
+            --bazelrc=.github/workflows/ci.bazelrc \
+            --bazelrc=.bazelrc \
+            test \
+            --disk_cache="${HOME}/.cache/bazel" \
+            --repository_cache="${HOME}/.cache/bazel-repo" \
+            //...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Mount bazel caches
+        uses: actions/cache@v2
+        with:
+          path: |
+            "~/.cache/bazel"
+            "~/.cache/bazel-repo"
+          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
+          restore-keys: bazel-cache-
       - name: bazel test //...
         env:
           # Bazelisk will download bazel to here
           XDG_CACHE_HOME: ~/.cache/bazel-repo
-        run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
+        run: |
+          bazel \
+            --bazelrc=.github/workflows/ci.bazelrc \
+            --bazelrc=.bazelrc \
+            test \
+            --disk_cache="${HOME}/.cache/bazel" \
+            --repository_cache="${HOME}/.cache/bazel-repo" \
+            //...
+
       - name: Prepare workspace snippet
         run: .github/workflows/workspace_snippet.sh ${{ env.GITHUB_REF_NAME }} > release_notes.txt
       - name: Release

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Ready to get started? Copy this repo, then
 1. rename directory "mylang" similarly
 1. run `pre-commit install` to get lints (see CONTRIBUTING.md)
 1. if you don't need to fetch platform-dependent tools, then remove anything toolchain-related.
+1. update the `actions/cache@v2` bazel cache key in [.github/workflows/ci.yaml](.github/workflows/ci.yaml) and [.github/workflows/release.yml](.github/workflows/release.yml) to be a hash of your source files.
 1. delete this section of the README (everything up to the SNIP).
 
 ---- SNIP ----


### PR DESCRIPTION
@alexeagle

Github actions caches don't update already existing caches, so the cache that gets loaded could be old. This sets a new cache using a cache key derived from a hash of files. The use of `restore-keys: bazel-cache-` will find the most recent cache stored scoped to this branch or a parent branch.