### PR TITLE
chore: Update github archive URLs to have stable SHAs

### DIFF
--- a/.github/workflows/workspace_snippet.sh
+++ b/.github/workflows/workspace_snippet.sh
@@ -16,7 +16,7 @@ http_archive(
     name = "com_myorg_rules_mylang",
     sha256 = "${SHA}",
     strip_prefix = "${PREFIX}",
-    url = "https://github.com/myorg/rules_mylang/archive/${TAG}.tar.gz",
+    url = "https://github.com/myorg/rules_mylang/archive/refs/tags/${TAG}.tar.gz",
 )
 
 # Fetches the rules_mylang dependencies.

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -49,7 +49,7 @@ def rules_mylang_internal_deps():
         strip_prefix = "bazel-skylib-1.1.1",
         urls = [
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/1.1.1.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/archive/1.1.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/archive/refs/tags/1.1.1.tar.gz",
         ],
     )
 


### PR DESCRIPTION
Required per https://github.com/bazel-contrib/SIG-rules-authors/issues/11