### PR TITLE
Declare toolchain only constrained by the exec platform

### DIFF
--- a/mylang/private/toolchains_repo.bzl
+++ b/mylang/private/toolchains_repo.bzl
@@ -86,10 +86,11 @@ resolved_toolchain(name = "resolved_toolchain", visibility = ["//visibility:publ
 
     for [platform, meta] in PLATFORMS.items():
         build_content += """
+# Declare a toolchain Bazel will select for running the tool in an action
+# on the execution platform.
 toolchain(
     name = "{platform}_toolchain",
     exec_compatible_with = {compatible_with},
-    target_compatible_with = {compatible_with},
     toolchain = "@{user_repository_name}_{platform}//:mylang_toolchain",
     toolchain_type = "@com_myorg_rules_mylang//mylang:toolchain_type",
 )


### PR DESCRIPTION
Typically we expect rules fetch toolchains for use during actions, so the toolchain selection should be based on the execution platform.
It's possible that tools may need to run on the target platform, but rulesets could still declare a second toolchain constrained by the target.

The code here is incorrect, as when the exec platform differs from the target platform, toolchain selection will find *no* matching toolchain