### PR TITLE
feat: add IntelliJ IDE folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bazel-*
 .bazelrc.user
+.idea/
+.ijwb/


### PR DESCRIPTION
Adds the standard `.idea` folder and the `.ijwb` created when used with the bazel plugin to the `.gitignore` folder in the template.