### PR TITLE
chore(deps): remove bazel-integration-testing

### DIFF
--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -13,15 +13,6 @@ def http_archive(name, **kwargs):
 def rules_mylang_internal_deps():
     "Fetch deps needed for local development"
     http_archive(
-        name = "build_bazel_integration_testing",
-        urls = [
-            "https://github.com/bazelbuild/bazel-integration-testing/archive/165440b2dbda885f8d1ccb8d0f417e6cf8c54f17.zip",
-        ],
-        strip_prefix = "bazel-integration-testing-165440b2dbda885f8d1ccb8d0f417e6cf8c54f17",
-        sha256 = "2401b1369ef44cc42f91dc94443ef491208dbd06da1e1e10b702d8c189f098e3",
-    )
-
-    http_archive(
         name = "io_bazel_rules_go",
         sha256 = "2b1641428dff9018f9e85c0384f03ec6c10660d935b750e3fa1492a281a53b0f",
         urls = [


### PR DESCRIPTION
This is unused within the template