### PR TITLE
Pin version of node to one supported on ubuntu 18.04.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,11 @@
 # but we don't want to run the other hooks on commit messages
 default_stages: [commit]
 
+# Use a slightly older version of node by default
+# as the default uses a very new version of GLIBC
+default_language_version:
+  node: 16.18.0
+
 repos:
   # Check formatting and lint for starlark code
   - repo: https://github.com/keith/pre-commit-buildifier


### PR DESCRIPTION
The default version of node that pre-commit downloads uses a very new version of GLIBC so set the default to an older version that will be more widely supported.