### PR TITLE
Fix usage of GitHub actions cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,8 +42,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            "~/.cache/bazel"
-            "~/.cache/bazel-repo"
+            ~/.cache/bazel
+            ~/.cache/bazel-repo
           key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
           restore-keys: bazel-cache-
       - name: bazel test //...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            "~/.cache/bazel"
-            "~/.cache/bazel-repo"
+            ~/.cache/bazel
+            ~/.cache/bazel-repo
           key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
           restore-keys: bazel-cache-
       - name: bazel test //...


### PR DESCRIPTION
Using quotes for the items in path does not resolve `~` correctly and
thus leads to the following warning in the post section:

```
Warning: Path Validation Error: Path(s) specified in the action for
caching do(es) not exist, hence no cache is being saved.
```
