### PR TITLE
Update internal_deps to latest and test with Bazel 6.0.0rc4 as well as Bazel 5.3.2

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-5.3.0
+6.0.0rc4
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,22 +11,52 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+    # Cancel previous actions from the same PR: https://stackoverflow.com/a/72408109
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 jobs:
+  # matrix-prep-* steps dynamically generate a bit of JSON depending on whether our action has
+  # access to repository secrets. When running on a pull_request from a fork, the author is
+  # untrusted so the secret will be absent. Insanely complex for how simple this requirement is...
+  # inspired from
+  # https://stackoverflow.com/questions/65384420/how-to-make-a-github-action-matrix-element-conditional
+
+  matrix-prep-bazelversion:
+    # Prepares the 'bazelversion' axis of the test matrix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - id: bazel_6
+        run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
+      - id: bazel_5
+        run: echo "bazelversion=5.3.2" >> $GITHUB_OUTPUT
+    outputs:
+      # Will look like ["<version from .bazelversion>", "5.3.2"]
+      bazelversions: ${{ toJSON(steps.*.outputs.bazelversion) }}
+
   test:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    
-    # Run bazel test in each workspace
+
+    needs:
+      - matrix-prep-bazelversion
+
+    # Run bazel test in each workspace with each version of Bazel supported
     strategy:
+      fail-fast: false
       matrix:
-          folder:
-              - '.'
-              - 'e2e/workspace'
+        bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
+        folder:
+          - "."
+          - "e2e/workspace"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
+
       # Cache build and external artifacts so that the next ci build is incremental.
       # Because github action caches cannot be updated after a build, we need to
       # store the contents of each build in a unique cache key, then fall back to loading
@@ -46,9 +76,29 @@ jobs:
             "~/.cache/bazel-repo"
           key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
           restore-keys: bazel-cache-
+
+      - name: Configure Bazel version
+        working-directory: ${{ matrix.folder }}
+        run: echo "${{ matrix.bazelversion }}" > .bazelversion
+
+      - name: Check for test.sh
+        # Checks for the existence of test.sh in the folder. Downstream steps can use
+        # steps.has_test_sh.outputs.files_exists as a conditional.
+        id: has_test_sh
+        uses: andstor/file-existence-action@v1
+        with:
+            files: '${{ matrix.folder }}/test.sh'
+
       - name: bazel test //...
         env:
           # Bazelisk will download bazel to here, ensure it is cached between runs.
           XDG_CACHE_HOME: ~/.cache/bazel-repo
         working-directory: ${{ matrix.folder }}
         run: bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
+
+      - name: ./test.sh
+        # Run if there is a test.sh file in the folder
+        if: steps.has_test_sh.outputs.files_exists == 'true'
+        working-directory: ${{ matrix.folder }}
+        shell: bash
+        run: ./test.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,10 +17,8 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  # matrix-prep-* steps dynamically generate a bit of JSON depending on whether our action has
-  # access to repository secrets. When running on a pull_request from a fork, the author is
-  # untrusted so the secret will be absent. Insanely complex for how simple this requirement is...
-  # inspired from
+  # matrix-prep-* steps generate JSON used to create a dynamic actions matrix.
+  # Insanely complex for how simple this requirement is inspired from
   # https://stackoverflow.com/questions/65384420/how-to-make-a-github-action-matrix-element-conditional
 
   matrix-prep-bazelversion:
@@ -28,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - id: bazel_6
+      - id: bazel_from_bazelversion
         run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
       - id: bazel_5
         run: echo "bazelversion=5.3.2" >> $GITHUB_OUTPUT

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,6 +34,6 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.17.2")
+go_register_toolchains(version = "1.19.3")
 
 gazelle_dependencies()

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,4 +1,4 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
-Public API re-exports
+
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,4 +1,16 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
+Public API re-exports
+
+<a id="example"></a>
+
+## example
+
+<pre>
+example()
+</pre>
+
+This is an example
+
 
 

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -14,20 +14,14 @@ def rules_mylang_internal_deps():
     "Fetch deps needed for local development"
     http_archive(
         name = "io_bazel_rules_go",
-        sha256 = "2b1641428dff9018f9e85c0384f03ec6c10660d935b750e3fa1492a281a53b0f",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
-            "https://github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
-        ],
+        sha256 = "099a9fb96a376ccbbb7d291ed4ecbdfd42f6bc822ab77ae6f1b5cb9e914e94fa",
+        urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip"],
     )
 
     http_archive(
         name = "bazel_gazelle",
-        sha256 = "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
-        ],
+        sha256 = "448e37e0dbf61d6fa8f00aaa12d191745e14f07c31cabfa731f0c8e8a4f41b97",
+        urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.28.0/bazel-gazelle-v0.28.0.tar.gz"],
     )
 
     # Override bazel_skylib distribution to fetch sources instead
@@ -35,26 +29,20 @@ def rules_mylang_internal_deps():
     # see https://github.com/bazelbuild/bazel-skylib/issues/250
     http_archive(
         name = "bazel_skylib",
-        sha256 = "07b4117379dde7ab382345c3b0f5edfc6b7cff6c93756eac63da121e0bbcc5de",
-        strip_prefix = "bazel-skylib-1.1.1",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/1.1.1.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/archive/refs/tags/1.1.1.tar.gz",
-        ],
+        sha256 = "3b620033ca48fcd6f5ef2ac85e0f6ec5639605fa2f627968490e52fc91a9932f",
+        strip_prefix = "bazel-skylib-1.3.0",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/refs/tags/1.3.0.tar.gz"],
     )
 
     http_archive(
         name = "io_bazel_stardoc",
-        sha256 = "05fb57bb4ad68a360470420a3b6f5317e4f722839abc5b17ec4ef8ed465aaa47",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.2/stardoc-0.5.2.tar.gz",
-            "https://github.com/bazelbuild/stardoc/releases/download/0.5.2/stardoc-0.5.2.tar.gz",
-        ],
+        sha256 = "3fd8fec4ddec3c670bd810904e2e33170bedfe12f90adf943508184be458c8bb",
+        urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz"],
     )
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "1cbbf62315d303c8083d5019a4657623d4f58e925fb51bdc8a41bad4a131f5c9",
-        strip_prefix = "bazel-lib-1.8.1",
-        url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.8.1.tar.gz",
+        sha256 = "be236556c7b9c7b91cb370e837fdcec62b6e8893408cd4465ae883c9d7c67024",
+        strip_prefix = "bazel-lib-1.18.0",
+        url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.18.0.tar.gz",
     )

--- a/mylang/defs.bzl
+++ b/mylang/defs.bzl
@@ -1,1 +1,7 @@
 "Public API re-exports"
+
+# Add your public API exports here
+
+def example():
+  """This is an example"""
+  print("example export")

--- a/mylang/defs.bzl
+++ b/mylang/defs.bzl
@@ -1,7 +1,5 @@
 "Public API re-exports"
 
-# Add your public API exports here
-
 def example():
   """This is an example"""
-  print("example export")
+  pass


### PR DESCRIPTION
Also adds the GH actions code to cancel previous CI runs for a PR (same as https://github.com/aspect-build/rules_js/pull/694) and to run `test.sh` if that is found at the root of the matrix folder. This is a simple and robust way to run e2e tests that need to make multiple bazel invocations or do other work besides `bazel test ...`