### PR TITLE
chore: publish release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,5 @@ jobs:
           # Use GH feature to populate the changelog automatically
           generate_release_notes: true
           body_path: release_notes.txt
+          fail_on_unmatched_files: true
+          files: rules_mylang-*.tar.gz

--- a/.github/workflows/workspace_snippet.sh
+++ b/.github/workflows/workspace_snippet.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset -o pipefail
 # Set by GH actions, see
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 TAG=${GITHUB_REF_NAME}
+# The prefix is chosen to match what GitHub generates for source archives
 PREFIX="rules_mylang-${TAG:1}"
-SHA=$(git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip | shasum -a 256 | awk '{print $1}')
+ARCHIVE="rules_mylang-$TAG.tar.gz"
+git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
+SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
 
 cat << EOF
 WORKSPACE snippet:
@@ -16,7 +19,7 @@ http_archive(
     name = "com_myorg_rules_mylang",
     sha256 = "${SHA}",
     strip_prefix = "${PREFIX}",
-    url = "https://github.com/myorg/rules_mylang/archive/refs/tags/${TAG}.tar.gz",
+    url = "https://github.com/myorg/rules_mylang/releases/download/${TAG}/rules_mylang-${TAG}.tar.gz",
 )
 EOF
 


### PR DESCRIPTION
GitHub had promised that their source archives would have stable checksums, but then there was a big Bazel outage yesterday due to their changing it. Even if they do make such a guarantee and stick to it, we also have the problem that GitHub doesn't give download metrics on their source archive so this is still worth changing.