### PR TITLE
chore: use reusable release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test:
-    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v1
+    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v2
     with:
       folders: '[".", "e2e/smoke"]'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,32 +9,7 @@ on:
       - "v*.*.*"
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Mount bazel caches
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/bazel
-            ~/.cache/bazel-repo
-          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
-          restore-keys: bazel-cache-
-      - name: bazel test //...
-        env:
-          # Bazelisk will download bazel to here
-          XDG_CACHE_HOME: ~/.cache/bazel-repo
-        run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
-      - name: Prepare release notes and artifacts
-        run: .github/workflows/release_prep.sh ${{ env.GITHUB_REF_NAME }} > release_notes.txt
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          prerelease: true
-          # Use GH feature to populate the changelog automatically
-          generate_release_notes: true
-          body_path: release_notes.txt
-          fail_on_unmatched_files: true
-          files: rules_mylang-*.tar.gz
+  release:
+    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v2
+    with:
+      release_files: rules_mylang-*.tar.gz


### PR DESCRIPTION
Reduces the amount of code that a fork of this repo ends up maintaining