### PR TITLE
docs: explicitly list all locations to replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Ready to get started? Copy this repo, then
 
 1. search for "com_myorg_rules_mylang" and replace with the name you'll use for your workspace
 1. search for "myorg" and replace with GitHub org
-1. search for "mylang" and replace with the language/tool your rules are for
+1. search for "mylang", "Mylang", "MYLANG" and replace with the language/tool your rules are for
 1. rename directory "mylang" similarly
 1. run `pre-commit install` to get lints (see CONTRIBUTING.md)
 1. if you don't need to fetch platform-dependent tools, then remove anything toolchain-related.


### PR DESCRIPTION
this is useful, since most tools like `grep` or `rg` search case insensitive by default