### PR TITLE
fix(e2e): set namespace prefix

### DIFF
--- a/e2e/smoke/BUILD
+++ b/e2e/smoke/BUILD
@@ -3,7 +3,7 @@ Add a basic smoke-test target below.
 """
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-# load("com_myorg_rules_mylang//mylang:defs.bzl", "...")
+# load("@com_myorg_rules_mylang//mylang:defs.bzl", "...")
 
 # Replace with a usage of your rule/macro
 filegroup(name = "empty")


### PR DESCRIPTION
Set `@` before the replaceable name in the `load` call within the `BUILD` of the Smoke tests.