### PR TITLE
Remove the Bazel repository cache

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -4,8 +4,10 @@
 # Debug where options came from
 build --announce_rc
 # This directory is configured in GitHub actions to be persisted between runs.
+# We do not enable the repository cache to cache downloaded external artifacts
+# as these are generally faster to download again than to fetch them from the
+# GitHub actions cache.
 build --disk_cache=~/.cache/bazel
-build --repository_cache=~/.cache/bazel-repo
 # Don't rely on test logs being easily accessible from the test runner,
 # though it makes the log noisier.
 test --test_output=errors

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test:
-    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v3
+    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@29e53247c6366e30acbedfc767f58f79fc05836c
     with:
       folders: |
         [


### PR DESCRIPTION
Closes https://github.com/bazel-contrib/rules-template/issues/76
Depends on https://github.com/bazel-contrib/.github/pull/7

Disables the Bazel repository cache. See #76 for motivation.

### TODO
- [x] Update the reference to the workflow version once https://github.com/bazel-contrib/.github/pull/7 is merged.