### PR TITLE
chore: update Renovate config with recommended ruleset settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"]
+  "extends": [
+    ":dependencyDashboard",
+    ":semanticPrefixFixDepsChoreOthers",
+    "group:monorepos",
+    "group:recommended",
+    "replacements:all",
+    "workarounds:all"
+  ],
+  "packageRules": [
+    {
+      "matchFiles": ["MODULE.bazel"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
Configure Renovate to disable updates for the ruleset, but allow updates for example and test workspaces.

Related to https://github.com/bazel-contrib/SIG-rules-authors/discussions/82.