### PR TITLE
chore(deps): update buildifier_prebuilt for CI to succeed on Windows

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "platforms", version = "0.0.5")
 bazel_dep(name = "gazelle", version = "0.29.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)
 bazel_dep(name = "aspect_bazel_lib", version = "1.32.1", dev_dependency = True)
-bazel_dep(name = "buildifier_prebuilt", version = "6.1.0", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "6.1.2", dev_dependency = True)
 
 mylang = use_extension("//mylang:extensions.bzl", "mylang")
 mylang.toolchain(mylang_version = "1.14.2")


### PR DESCRIPTION
Previously (keith/buildifier-prebuilt#68), buildifier CI checks will fail on Windows by default because the lack of Windows support for rule `buildifier_prebuilt`. This PR bumps `buildifier_prebuilt` to the version that supports Windows to fix this problem.
