### PR TITLE
Add and document minimal devcontainers setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/devcontainers/base:bookworm
+
+# Download bazelisk and place it in $PATH
+RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-amd64
+RUN chmod +x bazelisk-linux-amd64
+RUN mv bazelisk-linux-amd64 /usr/local/bin/bazel
+
+# Install python3 and pip to setup pre-commit
+RUN apt update && apt install -y --no-install-recommends \
+    python3-setuptools \
+    python3-pip \
+    python3-dev \
+    python3-venv
+
+# Install pre-commit
+RUN pip install --break-system-packages pre-commit

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+    "build": {
+      // instructs devcontainers to use a Dockerfile
+      // rather than a pre-defined image
+      "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+      "vscode": {
+        "extensions": [
+          "ms-azuretools.vscode-docker", // docker support
+          "BazelBuild.vscode-bazel" // bazel support
+        ]
+      }
+    },
+    // sets up pre-commit hooks
+    "postStartCommand": "pre-commit install"
+  }
+  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # How to Contribute
 
+## Using devcontainers
+
+If you are using [devcontainers](https://code.visualstudio.com/docs/devcontainers/containers)
+and/or [codespaces](https://github.com/features/codespaces) then you can start
+contributing immediately and skip the next step.
+
 ## Formatting
 
 Starlark files should be formatted by buildifier.


### PR DESCRIPTION
This makes contributing to projects forked from this template more intuitive and require no manual local setup.