### PR TITLE
feat: stamp the version into the artifact

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -2,6 +2,16 @@
 
 set -o errexit -o nounset -o pipefail
 
+# Configuration for 'git archive'
+# see https://git-scm.com/docs/git-archive/2.40.0#ATTRIBUTES
+cat >.git/info/attributes <<EOF
+# Substitution for the VERSION placeholder at the top of this file
+MODULE.bazel export-subst
+
+# Omit folders that users don't need, making the distribution artifact smaller 
+examples export-ignore
+EOF
+
 # Set by GH actions, see
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 TAG=${GITHUB_REF_NAME}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,8 +1,11 @@
 "Bazel dependencies"
 
+# replaced by export-subst during 'git archive'
+VERSION = "$Format:%(describe:tags=true)$"
+
 module(
     name = "com_myorg_rules_mylang",
-    version = "0.0.0",
+    version = "0.0.0" if VERSION.startswith("$Format") else VERSION,
     compatibility_level = 1,
 )
 


### PR DESCRIPTION
This avoids the need for Publish To BCR to create patch files like https://github.com/bazel-contrib/publish-to-bcr/pull/28 and reduces the clutter of `module_dot_bazel.patch` files in BCR