### PR TITLE
Revert release automation tagging

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -2,16 +2,6 @@
 
 set -o errexit -o nounset -o pipefail
 
-# Configuration for 'git archive'
-# see https://git-scm.com/docs/git-archive/2.40.0#ATTRIBUTES
-cat >.git/info/attributes <<EOF
-# Substitution for the VERSION placeholder at the top of this file
-MODULE.bazel export-subst
-
-# Omit folders that users don't need, making the distribution artifact smaller 
-examples export-ignore
-EOF
-
 # Set by GH actions, see
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 TAG=${GITHUB_REF_NAME}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,11 +1,8 @@
 "Bazel dependencies"
 
-# replaced by export-subst during 'git archive'
-VERSION = "$Format:%(describe:tags=true)$"
-
 module(
     name = "com_myorg_rules_mylang",
-    version = "0.0.0" if VERSION.startswith("$Format") else VERSION,
+    version = "0.0.0",
     compatibility_level = 1,
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ VERSION = "$Format:%(describe:tags=true)$"
 
 module(
     name = "com_myorg_rules_mylang",
-    version = "0.0.0" if VERSION.startswith("$Format") else VERSION.replace("v", "", 1),
+    version = "0.0.0" if VERSION.startswith("$Format") else VERSION,
     compatibility_level = 1,
 )
 


### PR DESCRIPTION
It doesn't work with Publish to BCR app's parsing of the file, and it's not important enough to spend time fixing that.