### PR TITLE
feat(release): exclude examples/ folder by default

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -2,6 +2,13 @@
 
 set -o errexit -o nounset -o pipefail
 
+# Don't include examples in the distribution artifact, to reduce size.
+# You may want to add additional exclusions for folders or files that users don't need.
+# NB: this mechanism relies on a `git archive` feature, which is much simpler and less
+# error-prone than using Bazel to build a release artifact from sources in the repository.
+# See https://git-scm.com/docs/git-archive#ATTRIBUTES
+echo >>.git/info/attributes "examples export-ignore"
+
 # Set by GH actions, see
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 TAG=${GITHUB_REF_NAME}


### PR DESCRIPTION
Shows how ruleset authors can make smaller release artifacts.