### PR TITLE
Give the releaser write permissions to the repo.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: write
+
 jobs:
   release:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v6


### PR DESCRIPTION
This is a known issue documented in https://github.com/softprops/action-gh-release/issues/236#issuecomment-1150530128

Fixes #64
