### PR TITLE
Remove incompatible_use_toolchain_transition

### DIFF
--- a/mylang/private/resolved_toolchain.bzl
+++ b/mylang/private/resolved_toolchain.bzl
@@ -22,6 +22,5 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["//mylang:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     doc = DOC,
 )


### PR DESCRIPTION
This is unused and toolchain transitions have been the default a while now and has been removed in bazel.
See: https://github.com/keith/bazel/commit/43d0f9683935e9886bb05dcc42ac83d6593ac205

cc @katre