### PR TITLE
feat: provide stable-named job for branch protection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,10 +38,14 @@ jobs:
     steps:
       - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3.0.3
 
-      - if: ${{ env.WORKFLOW_CONCLUSION == 'success' }}
+      # Note: possible conclusion values:
+      # https://github.com/technote-space/workflow-conclusion-action/blob/main/src/constant.ts
+      - name: report success
+        if: ${{ env.WORKFLOW_CONCLUSION == 'success' }}
         working-directory: /tmp
         run: echo ${{ env.WORKFLOW_CONCLUSION }} && exit 0
 
-      - if: ${{ env.WORKFLOW_CONCLUSION == 'failure' }}
+      - name: report failure
+        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' }}
         working-directory: /tmp
         run: echo ${{ env.WORKFLOW_CONCLUSION }} && exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,3 +29,19 @@ jobs:
         [
           {"folder": ".", "bzlmodEnabled": false}
         ]
+  # For branch protection settings, this job provides a "stable" name that can be used to gate PR merges
+  # on "all matrix jobs were successful".
+  conclusion:
+    needs: test
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3.0.3
+
+      - if: ${{ env.WORKFLOW_CONCLUSION == 'success' }}
+        working-directory: /tmp
+        run: echo ${{ env.WORKFLOW_CONCLUSION }} && exit 0
+
+      - if: ${{ env.WORKFLOW_CONCLUSION == 'failure' }}
+        working-directory: /tmp
+        run: echo ${{ env.WORKFLOW_CONCLUSION }} && exit 1


### PR DESCRIPTION
GitHub actions matrix "test" gets expanded to many status checks, making it impossible to keep the branch protection settings in the GitHub UI up-to-date as the matrix cells are updated.

This provides a "conclusion" status which can be used instead. Thanks @mattmoor for the code!

Demo: https://github.com/bazel-contrib/rules-template/actions/runs/9783272801/job/27011588324?pr=124