### PR TITLE
ci(pre-commit): Enable pre-commit CI and renovate

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,18 +1,17 @@
 {
-    "build": {
-      // instructs devcontainers to use a Dockerfile
-      // rather than a pre-defined image
-      "dockerfile": "Dockerfile"
-    },
-    "customizations": {
-      "vscode": {
-        "extensions": [
-          "ms-azuretools.vscode-docker", // docker support
-          "BazelBuild.vscode-bazel" // bazel support
-        ]
-      }
-    },
-    // sets up pre-commit hooks
-    "postStartCommand": "pre-commit install"
-  }
-  
+  "build": {
+    // instructs devcontainers to use a Dockerfile
+    // rather than a pre-defined image
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-docker", // docker support
+        "BazelBuild.vscode-bazel" // bazel support
+      ]
+    }
+  },
+  // sets up pre-commit hooks
+  "postStartCommand": "pre-commit install"
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,10 @@ on:
   workflow_dispatch:
 
 concurrency:
-    # Cancel previous actions from the same PR or branch except 'main' branch.
-    # See https://docs.github.com/en/actions/using-jobs/using-concurrency and https://docs.github.com/en/actions/learn-github-actions/contexts for more info.
-    group: concurrency-group::${{ github.workflow }}::${{ github.event.pull_request.number > 0 && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}${{ github.ref_name == 'main' && format('::{0}', github.run_id) || ''}}
-    cancel-in-progress: ${{ github.ref_name != 'main' }}
+  # Cancel previous actions from the same PR or branch except 'main' branch.
+  # See https://docs.github.com/en/actions/using-jobs/using-concurrency and https://docs.github.com/en/actions/learn-github-actions/contexts for more info.
+  group: concurrency-group::${{ github.workflow }}::${{ github.event.pull_request.number > 0 && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}${{ github.ref_name == 'main' && format('::{0}', github.run_id) || ''}}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,10 +29,15 @@ jobs:
         [
           {"folder": ".", "bzlmodEnabled": false}
         ]
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pre-commit/action@v3.0.1
   # For branch protection settings, this job provides a "stable" name that can be used to gate PR merges
   # on "all matrix jobs were successful".
   conclusion:
-    needs: test
+    needs: [test, pre-commit]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,18 +14,18 @@ default_language_version:
 repos:
   # Check formatting and lint for starlark code
   - repo: https://github.com/keith/pre-commit-buildifier
-    rev: 6.1.0.1
+    rev: 7.3.1.1
     hooks:
       - id: buildifier
       - id: buildifier-lint
   # Enforce that commit messages allow for later changelog generation
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.18.0
+    rev: v4.1.0
     hooks:
       # Requires that commitizen is already installed
       - id: commitizen
         stages: [commit-msg]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v2.4.0"
+    rev: v3.1.0
     hooks:
       - id: prettier

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Optional: if you write tools for your rules to call, you should avoid toolchain 
 For example, https://github.com/aspect-build/rules_py actions rely on a couple of binaries written in Rust, but we don't want users to be forced to
 fetch a working Rust toolchain. Instead we want to ship pre-built binaries on our GH releases, and the ruleset fetches these as toolchains.
 See https://blog.aspect.build/releasing-bazel-rulesets-rust for information on how to do this.
-Note that users who *do* want to build tools from source should still be able to do so, they just need to register a different toolchain earlier.
+Note that users who _do_ want to build tools from source should still be able to do so, they just need to register a different toolchain earlier.
 
 ---- SNIP ----
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     ":dependencyDashboard",
+    ":enablePreCommit",
     ":semanticPrefixFixDepsChoreOthers",
     "group:monorepos",
     "group:recommended",


### PR DESCRIPTION
Since the rules already prvide a pre-commit config, we should also make sure the checks pass CI and hooks stay up to date.