### PR TITLE
feat: use new Publish to BCR reusable workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,35 @@
+# Publish new releases to Bazel Central Registry.
+name: Publish to BCR
+on:
+  # Run the publish workflow after a successful release
+  # Will be triggered from the release.yaml workflow
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+    secrets:
+      publish_token:
+        required: true
+  # In case of problems, let release engineers retry by manually dispatching
+  # the workflow from the GitHub UI
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: git tag being released
+        required: true
+        type: string
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.0.4
+    with:
+      tag_name: ${{ inputs.tag_name }}
+      # GitHub repository which is a fork of the upstream where the Pull Request will be opened.
+      registry_fork: myorg/bazel-central-registry
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    secrets:
+      # Necessary to push to the BCR fork, and to open a pull request against a registry
+      publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,7 @@ on:
         type: string
 jobs:
   publish:
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.0.4
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.1.0
     with:
       tag_name: ${{ inputs.tag_name }}
       # GitHub repository which is a fork of the upstream where the Pull Request will be opened.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,15 +7,28 @@ on:
       tag_name:
         required: true
         type: string
+    secrets:
+      publish_token:
+        required: true
   # Or, developers can manually push a tag from their clone
   push:
     tags:
       - "v*.*.*"
 permissions:
+  id-token: write
+  attestations: write
   contents: write
 jobs:
   release:
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@0b644c3ee5c7cd9a7657f7e782b26a599d9b6d5c # 2025-01-23
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.2
     with:
       release_files: rules_mylang-*.tar.gz
-      tag_name: ${{ inputs.tag_name }}
+      prerelease: false
+      tag_name: ${{ github.ref_name }}
+  publish:
+    needs: release
+    uses: ./.github/workflows/publish.yaml
+    with:
+      tag_name: ${{ github.ref_name }}
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN || secrets.publish_token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,4 +31,4 @@ jobs:
     with:
       tag_name: ${{ github.ref_name }}
     secrets:
-      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN || secrets.publish_token }}
+      publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -15,10 +15,12 @@ on:
   # and releasing too infrequently which delays delivery of bugfixes and features.
   schedule:
     - cron: "0 15 1,15 * *"
+permissions:
+  id-token: write
+  attestations: write
+  contents: write
 jobs:
   tag:
-    permissions:
-      contents: write # allow create tag
     runs-on: ubuntu-latest
     outputs:
       new-tag: ${{ steps.ccv.outputs.new-tag }}
@@ -36,6 +38,8 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       tag_name: ${{ needs.tag.outputs.new-tag-version }}
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}
     if: needs.tag.outputs.new-tag == 'true' && needs.tag.outputs.new-tag-version-type != 'major'
     permissions:
       contents: write # allow create release

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -15,10 +15,10 @@ on:
   # and releasing too infrequently which delays delivery of bugfixes and features.
   schedule:
     - cron: "0 15 1,15 * *"
-permissions:
-  contents: write
 jobs:
   tag:
+    permissions:
+      contents: write # allow create tag
     runs-on: ubuntu-latest
     outputs:
       new-tag: ${{ steps.ccv.outputs.new-tag }}

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -16,8 +16,6 @@ on:
   schedule:
     - cron: "0 15 1,15 * *"
 permissions:
-  id-token: write
-  attestations: write
   contents: write
 jobs:
   tag:


### PR DESCRIPTION
Includes attestations for provenance of release artifacts