### PR TITLE
pre-commit migrate-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 # Commitizen runs in commit-msg stage
 # but we don't want to run the other hooks on commit messages
-default_stages: [commit]
+default_stages: [pre-commit]
 # Use a slightly older version of node by default
 # as the default uses a very new version of GLIBC
 default_language_version:


### PR DESCRIPTION
With the version 3.2.0 of pre-commit the stage `commit` is deprecated and replace with `pre-commit`.
See : https://pre-commit.com/#confining-hooks-to-run-at-certain-stages

Without that you will have a warning when running pre-commit hooks : 
```
[WARNING] top-level `default_stages` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
```