### PR TITLE
fix: Add new-tag-version-type as an output to the tag job before referring it from release

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       new-tag: ${{ steps.ccv.outputs.new-tag }}
       new-tag-version: ${{steps.ccv.outputs.new-tag-version}}
+      new-tag-version-type: ${{steps.ccv.outputs.new-tag-version-type}}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Without this I am running into:

```
.github/workflows/tag.yaml:41:48: property "new-tag-version-type" is not defined in object type {new-tag: string; new-tag-version: string} [expression]
```