### PR TITLE
fix: don't set module version outside BCR

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,8 +2,32 @@
 
 module(
     name = "com_myorg_rules_mylang",
-    version = "0.0.0",
-    compatibility_level = 1,
+
+    # NOTE:
+    # version = "",
+    #
+    # Always leave version unset or set to "" (the default). The default value
+    # can prevent issues when the module is used via non-registry overrides
+    # (e.g. https://github.com/bazel-contrib/rules_go/issues/4380).
+    #
+    # The publish.yaml GitHub Action sets the version in the registry to the
+    # release version by patching this MODULE.bazel file in the pull request to
+    # the BCR.
+    #
+    # For more info, see this Slack thread:
+    # https://bazelbuild.slack.com/archives/CA31HN1T3/p1750406404452179
+
+    # NOTE:
+    # compatibility_level = 0,
+    #
+    # Bumping compatibility_level too frequently is discouraged because it's
+    # very disruptive: as soon as a module is requested at two different
+    # compatibility levels in the dependency tree, users will see an error.
+    #
+    # As such, the compatibility_level (1) should be bumped *only* when the
+    # breaking change affects most use cases and isn't easy to migrate and/or
+    # work-around, and (2) *in the same commit* that introduces an incompatible
+    # (breaking) change.
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")


### PR DESCRIPTION
Leaving the version unset or set to the default value (`""`) can prevent issues when the module is used via non-registry overrides (e.g. https://github.com/bazel-contrib/rules_go/issues/4380).

The [publish.yaml](https://github.com/bazel-contrib/rules-template/blob/17dbddc928dab2ee7ea8439819bcad8201e9afb7/.github/workflows/publish.yaml) GitHub Action sets the version in the registry to the release version by patching the `MODULE.bazel` file in the pull request to the BCR.

Also, set `compatibility_level` back to the default by commenting it out and explicitly setting it to the default value in the comment and adding a note about the best practice re. when and how to bump it.

Thanks to fmeum for all the help and context regarding these issues!

For more info, see this Slack thread:
https://bazelbuild.slack.com/archives/CA31HN1T3/p1750406404452179