### PR TITLE
fix(github-actions): update reference to release.yaml in tag.yaml

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: smlx/ccv@7318e2f25a52dcd550e75384b84983973251a1f8 # v0.10.0
   release:
     needs: tag
-    uses: ./.github/workflows/release.yml
+    uses: ./.github/workflows/release.yaml
     with:
       tag_name: ${{ needs.tag.outputs.new-tag-version }}
     secrets:


### PR DESCRIPTION
What I assume is a fix for https://github.com/tharakadesilva/rules_spring_aot/actions/runs/16100304948/workflow

EDIT: It definitely fixes the original issue, but there is a new one: https://github.com/tharakadesilva/rules_spring_aot/actions/runs/16120615257/job/45485199842

Can merge this, will look into the other issue separately.