### PR TITLE
ci: Update platform versions in presubmit.yml

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: "e2e/smoke"
   matrix:
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["debian11", "macos", "ubuntu2204", "windows"]
     bazel: ["8.x", "7.x", "6.x"]
   tasks:
     run_tests:


### PR DESCRIPTION
Ubuntu 20.04 and Debian 10 are EOL, see https://ubuntu.com/about/release-cycle and https://wiki.debian.org/LTS. Make sure we use actively maintained platforms for testing BCR presubmits.