### PR TITLE
chore: remove publish-to-bcr config file

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,6 +1,0 @@
-# See https://github.com/bazel-contrib/publish-to-bcr#a-note-on-release-automation
-# for guidance about whether to uncomment this section:
-#
-# fixedReleaser:
-#   login: my_github_handle
-#   email: me@my.org

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,10 +46,6 @@ repos:
     rev: v0.14.0
     hooks:
       - id: yamlfmt
-        exclude: |
-          (?x)^(
-            .bcr/config.yml
-          )
   - repo: https://github.com/crate-ci/typos
     rev: v1.38.1
     hooks:


### PR DESCRIPTION
The `fixedReleaser` option is only relevant for the GitHub app which is deprecated.