### PR TITLE
chore: use a modern release/publish flow for immutable releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,11 +21,16 @@ on:
         type: string
 jobs:
   publish:
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.0.0
+    # https://github.com/bazel-contrib/publish-to-bcr/blob/main/.github/workflows/publish.yaml
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.4.1
     with:
       tag_name: ${{ inputs.tag_name }}
       # GitHub repository which is a fork of the upstream where the Pull Request will be opened.
       registry_fork: myorg/bazel-central-registry
+      # Modules under personal GitHub accounts should set draft: true.
+      # Modules under a GitHub org using a machine user PAT should set draft: false.
+      # See https://github.com/bazel-contrib/publish-to-bcr#4-consider-whether-to-open-the-pr-as-a-draft
+      draft: true
     permissions:
       attestations: write
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,10 +20,17 @@ permissions:
   contents: write
 jobs:
   release:
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.2
+    # https://github.com/bazel-contrib/.github/blob/master/.github/workflows/release_ruleset.yaml
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.7.7
     with:
       release_files: rules_mylang-*.tar.gz
       prerelease: false
+      # Open the release as a draft to support immutable GitHub releases.
+      # Attestations will be uploaded to the draft in publish.yaml.
+      # See:
+      #   https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases.
+      #   https://github.com/bazel-contrib/publish-to-bcr#immutable-releases
+      draft: true
       tag_name: ${{ inputs.tag_name || github.ref_name }}
   publish:
     needs: release
@@ -32,3 +39,11 @@ jobs:
       tag_name: ${{ inputs.tag_name || github.ref_name }}
     secrets:
       publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}
+  finalize:
+    # Publish the draft release
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        with:
+          tag_name: ${{ inputs.tag_name || github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Features:
 - includes typical toolchain setup
 - CI configured with GitHub Actions
 - release using GitHub Actions just by pushing a tag
+- release flow supports GitHub [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases)
 - the release artifact doesn't need to be built by Bazel, but can still exclude files and stamp the version
 
 Ready to get started? Copy this repo, then


### PR DESCRIPTION
Update the release/publish workflows to support immutable GitHub releases.