### PR TITLE
fix: reusable release workflow version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   release:
     # https://github.com/bazel-contrib/.github/blob/master/.github/workflows/release_ruleset.yaml
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.7.7
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.7.0
     with:
       release_files: rules_mylang-*.tar.gz
       prerelease: false


### PR DESCRIPTION
I made a typo in https://github.com/bazel-contrib/rules-template/commit/a3fcfe9eb68cbddb13e0d2d4950d0dec6b56b324 causing the daily tag release to [fail](https://github.com/bazel-contrib/rules-template/actions/runs/27708482317).