### PR TITLE
feat: split toolchain type into execution and target types

### DIFF
--- a/mylang/private/toolchains_repo.bzl
+++ b/mylang/private/toolchains_repo.bzl
@@ -63,7 +63,14 @@ toolchain(
     name = "{platform}_toolchain",
     exec_compatible_with = {compatible_with},
     toolchain = "@{user_repository_name}_{platform}//:mylang_toolchain",
-    toolchain_type = "@com_myorg_rules_mylang//mylang/toolchain:toolchain_type",
+    toolchain_type = "@com_myorg_rules_mylang//mylang/toolchain:execution_type",
+)
+
+toolchain(
+    name = "{platform}_target_toolchain",
+    target_compatible_with = {compatible_with},
+    toolchain = "@{user_repository_name}_{platform}//:mylang_toolchain",
+    toolchain_type = "@com_myorg_rules_mylang//mylang/toolchain:target_type",
 )
 """.format(
             platform = platform,

--- a/mylang/toolchain/BUILD.bazel
+++ b/mylang/toolchain/BUILD.bazel
@@ -9,5 +9,5 @@ package(default_visibility = ["//visibility:public"])
 # Resolve the mylang tool for the execution platform.
 toolchain_type(name = "execution_type")
 
-# Less frequently needed: give a diff tool for the target platform.
+# Less frequently needed: give a mylang tool for the target platform.
 toolchain_type(name = "target_type")

--- a/mylang/toolchain/BUILD.bazel
+++ b/mylang/toolchain/BUILD.bazel
@@ -1,7 +1,13 @@
-# This is the target rule authors should put in their "toolchains"
-# attribute in order to get a runtime for the correct platform.
-# See https://docs.bazel.build/versions/main/toolchains.html#writing-rules-that-use-toolchains
-toolchain_type(
-    name = "toolchain_type",
-    visibility = ["//visibility:public"],
-)
+"""
+These are the targets rule authors should put in their "toolchains"
+attribute in order to get a runtime for the correct platform.
+See https://docs.bazel.build/versions/main/toolchains.html
+"""
+
+package(default_visibility = ["//visibility:public"])
+
+# Resolve the mylang tool for the execution platform.
+toolchain_type(name = "execution_type")
+
+# Less frequently needed: give a diff tool for the target platform.
+toolchain_type(name = "target_type")


### PR DESCRIPTION
Demonstrate best practice of having separate toolchain types for the execution and target platforms.