### PR TITLE
feat: don't register toolchain by default

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -30,5 +30,11 @@ Add to your \`MODULE.bazel\` file:
 
 \`\`\`starlark
 bazel_dep(name = "com_myorg_rules_mylang", version = "${TAG:1}")
+
+mylang = use_extension("@com_myorg_rules_mylang//mylang:extensions.bzl", "mylang")
+mylang.toolchain(mylang_version = "1.14.2")
+use_repo(mylang, "mylang_toolchains")
+
+register_toolchains("@mylang_toolchains//:all")
 \`\`\`
 EOF

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -40,8 +40,11 @@ bazel_dep(name = "bazel_lib", version = "3.0.0", dev_dependency = True)
 
 bazel_dep(name = "bazelrc-preset.bzl", version = "1.6.0")
 
-mylang = use_extension("//mylang:extensions.bzl", "mylang")
+mylang = use_extension("//mylang:extensions.bzl", "mylang", dev_dependency = True)
 mylang.toolchain(mylang_version = "1.14.2")
 use_repo(mylang, "mylang_toolchains")
 
-register_toolchains("@mylang_toolchains//:all")
+register_toolchains(
+    "@mylang_toolchains//:all",
+    dev_dependency = True,
+)

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -5,3 +5,9 @@ local_path_override(
     module_name = "com_myorg_rules_mylang",
     path = "../..",
 )
+
+mylang = use_extension("@com_myorg_rules_mylang//mylang:extensions.bzl", "mylang")
+mylang.toolchain(mylang_version = "1.14.2")
+use_repo(mylang, "mylang_toolchains")
+
+register_toolchains("@mylang_toolchains//:all")


### PR DESCRIPTION
It seems like best practice to not force default toolchain registrations in case the configuration is complex and the defaults aren't always what people what. I had a discussion about it [here](https://bazelbuild.slack.com/archives/C014RARENH0/p1779121360640289).